### PR TITLE
Update macos_version.txt

### DIFF
--- a/.github/macos_version.txt
+++ b/.github/macos_version.txt
@@ -1,1 +1,1 @@
-macOS-12
+macOS-13


### PR DESCRIPTION
macOS 12 runner don't exist, and #170 blocks moving to something newer